### PR TITLE
feat(editor): add revision history and conflict guard

### DIFF
--- a/components/editor/HolyEditor.tsx
+++ b/components/editor/HolyEditor.tsx
@@ -6,7 +6,7 @@ import Image from '@tiptap/extension-image';
 import Placeholder from '@tiptap/extension-placeholder';
 import Highlight from '@tiptap/extension-highlight';
 import Focus from '@tiptap/extension-focus';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Toolbar } from './Toolbar';
 import SelectionMiniBar from './SelectionMiniBar';
@@ -24,14 +24,16 @@ interface HolyEditorProps {
 }
 
 export default function HolyEditor({ documentId }: HolyEditorProps) {
-  const { sermonInfo, setSermonInfo, setDocumentId, setEditorContent, setCurrentFolderId, resetForNewDocument } = useEditorContext();
+  const { sermonInfo, setSermonInfo, setDocumentId, setEditorContent, setCurrentFolderId, resetForNewDocument, syncServerHash, markClean } = useEditorContext();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const utils = api.useUtils();
   // 로컬 변경/초기 적용 가드(업로드 이미지 사라짐 방지)
   const hasLocalEditsRef = useRef(false);
   const initialContentAppliedRef = useRef(false);
   // 사용자가 실제로 입력했는지 여부(자동저장 가드)
   const userInteractedRef = useRef(false);
+  const [showRevisionPanel, setShowRevisionPanel] = useState(false);
   
   // tRPC query for loading document
   const { data: document, isLoading } = api.document.getById.useQuery(
@@ -48,6 +50,68 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
     { id: activeFolderId as string },
     { enabled: !!activeFolderId }
   );
+  const canUseRevisions = !!documentId && documentId !== 'new';
+  const { data: revisions, isLoading: isLoadingRevisions, refetch: refetchRevisions, isFetching: isFetchingRevisions } = api.document.revisions.useQuery(
+    { documentId: documentId! , limit: 10 },
+    { enabled: canUseRevisions }
+  );
+  const restoreRevision = api.document.restoreFromRevision.useMutation({
+    onSuccess: async (data) => {
+      toast.success('이전 버전으로 복원했습니다');
+      setShowRevisionPanel(false);
+      await refetchRevisions();
+      if (data?.content && editor) {
+        try {
+          editor.commands.setContent(data.content as any, { emitUpdate: false });
+          hasLocalEditsRef.current = false;
+          initialContentAppliedRef.current = true;
+          userInteractedRef.current = false;
+          setEditorContent(data.content as any);
+          const sermonData = (data.content as any)?.sermonInfo || {};
+          setSermonInfo({
+            title: data.title || sermonData.title || '',
+            pastor: sermonData.pastor || '',
+            verse: sermonData.verse || '',
+            serviceType: (normalizeServiceType(sermonData.serviceType) as SermonInfo['serviceType']) || '주일설교'
+          });
+          syncServerHash(data.content);
+          markClean();
+        } catch (err) {
+          console.error('복원 콘텐츠 적용 실패:', err);
+        }
+      }
+      if (documentId) {
+        await utils.document.getById.invalidate({ id: documentId });
+      }
+    },
+    onError: (error) => {
+      console.error('리비전 복원 실패:', error);
+      const code = (error as any)?.data?.code;
+      if (code === 'UNAUTHORIZED') {
+        toast.error('로그인이 필요합니다');
+        router.push('/login');
+        return;
+      }
+      toast.error('복원 중 오류가 발생했습니다');
+    },
+  });
+
+  const handleRestoreRevision = async (revisionId: string) => {
+    if (!documentId) return;
+    const confirmed = window.confirm('선택한 저장본으로 되돌립니다. 현재 편집 중 내용은 사라집니다. 진행할까요?');
+    if (!confirmed) return;
+    await restoreRevision.mutateAsync({ documentId, revisionId });
+  };
+
+  const toggleRevisionPanel = () => {
+    setShowRevisionPanel((prev) => {
+      const next = !prev;
+      if (!prev && canUseRevisions) {
+        void refetchRevisions();
+      }
+      return next;
+    });
+  };
   // 폴더 미선택 가드: 새 문서인데 폴더 미지정이면 폴더 페이지로 유도
   useEffect(() => {
     if (!documentId && !folderIdFromQuery) {
@@ -55,6 +119,12 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
       router.push('/folders');
     }
   }, [documentId, folderIdFromQuery, router]);
+
+  useEffect(() => {
+    if (!documentId || documentId === 'new') {
+      setShowRevisionPanel(false);
+    }
+  }, [documentId]);
   
   // Context에 documentId 설정
   useEffect(() => {
@@ -177,6 +247,13 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
         verse: sermonData.verse || '',
         serviceType: (normalizeServiceType(sermonData.serviceType) as SermonInfo['serviceType']) || '주일설교'
       });
+      if (document.content && typeof document.content === 'object') {
+        setEditorContent(document.content as any);
+        syncServerHash(document.content as any);
+        if (!hasLocalEditsRef.current) {
+          markClean();
+        }
+      }
       
       // editor content 설정: 로컬 편집이 없고, 아직 초기 적용 전일 때만 1회 적용
       if (
@@ -197,7 +274,7 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
       console.error('문서를 찾을 수 없습니다');
       router.push('/folders');
     }
-  }, [editor, documentId, document, isLoading, setSermonInfo, router]);
+  }, [editor, documentId, document, isLoading, setSermonInfo, setEditorContent, syncServerHash, markClean, router]);
 
   // 새 문서 진입 시: 전역 상태 초기화 + 에디터 내용 비우기(초기 업데이트 억제)
   useEffect(() => {
@@ -246,6 +323,50 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
             <span>{activeFolder.icon ?? '📁'}</span>
             <span className="font-medium text-gray-700">{activeFolder.name}</span>
           </span>
+        </div>
+      )}
+      {canUseRevisions && (
+        <div className="mb-4 rounded-lg border bg-white px-3 py-2 text-xs text-gray-700">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">저장 안전장치</span>
+            <button
+              type="button"
+              onClick={toggleRevisionPanel}
+              className="rounded bg-primary/10 px-2 py-1 font-semibold text-primary hover:bg-primary/20"
+            >
+              {showRevisionPanel ? '이전 버전 숨기기' : '이전 버전 보기'}
+            </button>
+          </div>
+          {showRevisionPanel && (
+            <div className="mt-2 max-h-56 space-y-2 overflow-y-auto">
+              {isLoadingRevisions || isFetchingRevisions ? (
+                <div className="text-[11px] text-muted-foreground">이전 버전을 불러오는 중...</div>
+              ) : (revisions && revisions.length > 0 ? (
+                revisions.map((rev) => {
+                  const createdAt = rev.createdAt instanceof Date ? rev.createdAt : new Date(rev.createdAt as unknown as string);
+                  const formatted = new Intl.DateTimeFormat('ko-KR', { dateStyle: 'medium', timeStyle: 'short' }).format(createdAt);
+                  return (
+                    <div key={rev.id} className="flex items-center justify-between rounded border px-3 py-2">
+                      <div className="flex flex-col">
+                        <span className="text-sm font-medium">{formatted}</span>
+                        <span className="text-[11px] text-gray-500">저장자: {rev.userId ? (rev.userId === (document as any)?.userId ? '나' : rev.userId.slice(0, 8) + '…') : '알 수 없음'}</span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleRestoreRevision(rev.id)}
+                        className="rounded border border-primary px-2 py-1 text-xs font-semibold text-primary hover:bg-primary/10 disabled:opacity-50"
+                        disabled={restoreRevision.isPending}
+                      >
+                        복원
+                      </button>
+                    </div>
+                  );
+                })
+              ) : (
+                <div className="text-[11px] text-muted-foreground">저장된 이전 버전이 없습니다.</div>
+              ))}
+            </div>
+          )}
         </div>
       )}
       <SermonInfoSection 

--- a/contexts/EditorContext.tsx
+++ b/contexts/EditorContext.tsx
@@ -7,6 +7,17 @@ import { api } from '@/utils/api';
 import toast from 'react-hot-toast';
 import { attachSermonInfo } from '@/lib/editor/content';
 
+const fingerprint = (obj: unknown) => {
+  try {
+    const s = JSON.stringify(obj);
+    let h = 5381;
+    for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
+    return (h >>> 0).toString(36);
+  } catch {
+    return Math.random().toString(36).slice(2, 8);
+  }
+};
+
 interface EditorContextType {
   sermonInfo: SermonInfo;
   setSermonInfo: (info: SermonInfo) => void;
@@ -21,6 +32,10 @@ interface EditorContextType {
   lastAutoSavedAt?: Date;
   /** 새 문서 진입 시 상태를 초기화합니다. (dirty/hash/내용/설교정보/문서ID/폴더ID) */
   resetForNewDocument: (folderId?: string) => void;
+  /** 서버에서 불러온 최신 content 해시를 동기화합니다. */
+  syncServerHash: (content: any) => void;
+  /** 강제 덮어쓰기 후 더티 플래그를 수동으로 초기화합니다. */
+  markClean: () => void;
 }
 
 const EditorContext = createContext<EditorContextType | undefined>(undefined);
@@ -71,6 +86,18 @@ export function EditorProvider({ children }: { children: ReactNode }) {
       resettingRef.current = false;
     }
   }, []);
+
+  const syncServerHash = useCallback((content: any) => {
+    if (content) {
+      lastSavedHashRef.current = fingerprint(content);
+    } else {
+      lastSavedHashRef.current = undefined;
+    }
+  }, []);
+
+  const markClean = useCallback(() => {
+    dirtyRef.current = false;
+  }, []);
   
   // tRPC mutations
   const createDocument = api.document.create.useMutation({
@@ -104,9 +131,20 @@ export function EditorProvider({ children }: { children: ReactNode }) {
       if (code === 'UNAUTHORIZED') {
         toast.error('로그인이 필요합니다');
         router.push('/login?returnTo=' + encodeURIComponent(`/editor/${documentId ?? 'new'}`));
-      } else {
-        toast.error('저장 중 오류가 발생했습니다');
+        return;
       }
+      if (code === 'CONFLICT') {
+        toast.error('다른 기기에서 먼저 저장되었습니다. 페이지 새로고침 후 복구 메뉴를 이용해주세요.');
+        if (documentId) {
+          utils.document.getById.invalidate({ id: documentId });
+        }
+        return;
+      }
+      if (code === 'BAD_REQUEST') {
+        toast.error('비어 있는 내용으로는 저장할 수 없습니다. 내용을 확인해주세요.');
+        return;
+      }
+      toast.error('저장 중 오류가 발생했습니다');
     },
   });
 
@@ -128,21 +166,11 @@ export function EditorProvider({ children }: { children: ReactNode }) {
         content: contentWithMeta,
         isPublic: false,
       };
-
-      // fingerprint for verification/logging
-      const fingerprint = (obj: unknown) => {
-        try {
-          const s = JSON.stringify(obj);
-          // djb2
-          let h = 5381;
-          for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
-          return (h >>> 0).toString(36);
-        } catch { return Math.random().toString(36).slice(2,8); }
-      };
-      const expectedHash = fingerprint(documentData.content);
+      const previousHash = lastSavedHashRef.current;
+      const newHash = fingerprint(documentData.content);
 
       const saveStart = new Date();
-      console.log('[SAVE] manual start', { id: documentId ?? 'new', at: saveStart.toISOString(), hash: expectedHash });
+      console.log('[SAVE] manual start', { id: documentId ?? 'new', at: saveStart.toISOString(), hash: newHash, previousHash });
 
       let targetId = documentId;
       if (documentId && documentId !== 'new') {
@@ -152,7 +180,8 @@ export function EditorProvider({ children }: { children: ReactNode }) {
             ...documentData,
             // 편집 중 폴더가 바뀌는 시나리오 고려(선택적)
             ...(currentFolderId ? { folderId: currentFolderId } : {}),
-          }
+          },
+          expectedHash: previousHash,
         });
       } else {
         const created = await createDocument.mutateAsync({
@@ -162,15 +191,18 @@ export function EditorProvider({ children }: { children: ReactNode }) {
         targetId = created?.id ?? targetId;
       }
 
+      lastSavedHashRef.current = newHash;
+      dirtyRef.current = false;
+
       // 서버 반영 검증 1회
       try {
         if (targetId) {
           const fresh = await utils.document.getById.fetch({ id: targetId });
           const serverHash = fingerprint((fresh as any)?.content);
-          if (serverHash !== expectedHash) {
-            console.warn('[SAVE] verify mismatch, retry once', { targetId, expectedHash, serverHash });
-            // 1회 재시도
-            await updateDocument.mutateAsync({ id: targetId, data: documentData });
+          if (serverHash !== newHash) {
+            console.warn('[SAVE] verify mismatch', { targetId, expected: newHash, server: serverHash });
+            toast.error('서버에 다른 내용이 저장되어 있습니다. 복구 메뉴에서 확인해주세요.');
+            lastSavedHashRef.current = serverHash;
           } else {
             console.log('[SAVE] verify ok', { targetId, hash: serverHash });
           }
@@ -220,14 +252,8 @@ export function EditorProvider({ children }: { children: ReactNode }) {
         ...(currentFolderId ? { folderId: currentFolderId } : {}),
       };
       // 중복 저장 방지: 동일 해시면 스킵
-      const fingerprint = (obj: unknown) => {
-        try {
-          const s = JSON.stringify(obj);
-          let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h) ^ s.charCodeAt(i);
-          return (h >>> 0).toString(36);
-        } catch { return Math.random().toString(36).slice(2,8); }
-      };
       const hash = fingerprint(data.content);
+      const previousHash = lastSavedHashRef.current;
       if (lastSavedHashRef.current === hash) {
         dirtyRef.current = false;
         autoSavingRef.current = false;
@@ -238,7 +264,7 @@ export function EditorProvider({ children }: { children: ReactNode }) {
       console.log('[SAVE] autosave start', { id: documentId ?? 'new', at: start.toISOString(), hash });
 
       if (documentId && documentId !== 'new') {
-        await updateDocumentSilent.mutateAsync({ id: documentId, data });
+        await updateDocumentSilent.mutateAsync({ id: documentId, data, expectedHash: previousHash });
       } else {
         // 새 문서일 경우 1회만 생성 후 URL 교체, 이후 모두 update
         const created = await createDocumentSilent.mutateAsync({ ...data });
@@ -253,6 +279,15 @@ export function EditorProvider({ children }: { children: ReactNode }) {
       // 자동저장에서는 무분별한 캐시 무효화 생략
     } catch (e) {
       console.error('자동 저장 실패:', e);
+      const code = (e as any)?.data?.code;
+      if (code === 'CONFLICT') {
+        toast.error('자동 저장이 충돌했습니다. 페이지를 새로고침한 뒤 다시 시도해주세요.');
+        if (documentId) {
+          utils.document.getById.invalidate({ id: documentId });
+        }
+      } else if (code === 'BAD_REQUEST') {
+        toast.error('내용이 비어 있어 자동 저장하지 못했습니다. 내용을 확인해주세요.');
+      }
     } finally {
       autoSavingRef.current = false;
     }
@@ -294,6 +329,8 @@ export function EditorProvider({ children }: { children: ReactNode }) {
         setCurrentFolderId,
         lastAutoSavedAt,
         resetForNewDocument,
+        syncServerHash,
+        markClean,
       }}
     >
       {children}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,12 +33,25 @@ model Document {
   updatedAt       DateTime         @updatedAt
   bibleReferences BibleReference[]
   tags            DocumentTag[]
+  revisions       DocumentRevision[]
   user            User?            @relation(fields: [userId], references: [id], onDelete: Cascade)
   folder          Folder?          @relation(fields: [folderId], references: [id], onDelete: SetNull)
 
   @@index([userId])
   @@index([folderId])
   @@map("documents")
+}
+
+model DocumentRevision {
+  id         String   @id @default(cuid())
+  documentId String
+  userId     String?
+  content    Json
+  createdAt  DateTime @default(now())
+  document   Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  @@index([documentId, createdAt])
+  @@map("document_revisions")
 }
 
 model BibleReference {

--- a/server/api/routers/document.ts
+++ b/server/api/routers/document.ts
@@ -1,6 +1,56 @@
 import { z } from 'zod';
-import { createTRPCRouter, publicProcedure, protectedProcedure } from '@/server/api/trpc';
+import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc';
 import { TRPCError } from '@trpc/server';
+
+const FRESH_REVISION_LIFETIME_DAYS = 7;
+
+const fingerprint = (obj: unknown) => {
+  try {
+    const s = JSON.stringify(obj);
+    let h = 5381;
+    for (let i = 0; i < s.length; i++) {
+      h = ((h << 5) + h) ^ s.charCodeAt(i);
+    }
+    return (h >>> 0).toString(36);
+  } catch {
+    return Math.random().toString(36).slice(2, 8);
+  }
+};
+
+const hasMeaningfulContent = (content: unknown): boolean => {
+  if (!content || typeof content !== 'object') return false;
+  const maybeDoc = content as { content?: unknown };
+  const search = (node: unknown): boolean => {
+    if (!node) return false;
+    if (Array.isArray(node)) {
+      return node.some(search);
+    }
+    if (typeof node !== 'object') return false;
+    const obj = node as Record<string, unknown>;
+    const text = obj.text;
+    if (typeof text === 'string' && text.trim().length > 0) {
+      return true;
+    }
+    if (Array.isArray(obj.content) && obj.content.length > 0) {
+      return obj.content.some(search);
+    }
+    return false;
+  };
+  if (Array.isArray((maybeDoc as any).content)) {
+    return search((maybeDoc as any).content);
+  }
+  return false;
+};
+
+const pruneOldRevisions = async (prisma: any, documentId: string) => {
+  const threshold = new Date(Date.now() - FRESH_REVISION_LIFETIME_DAYS * 24 * 60 * 60 * 1000);
+  await prisma.documentRevision.deleteMany({
+    where: {
+      documentId,
+      createdAt: { lt: threshold },
+    },
+  });
+};
 
 // Document 입력 스키마
 const documentInputSchema = z.object({
@@ -31,6 +81,15 @@ export const documentRouter = createTRPCRouter({
           userId: ctx.user.id, // 인증된 사용자의 ID
         },
       });
+
+      await ctx.prisma.documentRevision.create({
+        data: {
+          documentId: document.id,
+          userId: ctx.user.id,
+          content: document.content,
+        },
+      });
+      await pruneOldRevisions(ctx.prisma, document.id);
 
       return document;
     }),
@@ -112,10 +171,10 @@ export const documentRouter = createTRPCRouter({
       z.object({
         id: z.string(),
         data: documentInputSchema.partial(),
+        expectedHash: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // 소유권 검사
       const document = await ctx.prisma.document.findUnique({
         where: { id: input.id },
       });
@@ -127,12 +186,53 @@ export const documentRouter = createTRPCRouter({
         });
       }
 
-      // Prisma 스키마에 존재하는 필드만 업데이트
-      const allowedData: any = { updatedAt: new Date() };
+      const currentHash = fingerprint(document.content);
+      if (input.expectedHash && input.expectedHash !== currentHash) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: '문서가 다른 기기에서 우선 저장되었습니다. 새로고침 후 다시 시도해주세요.',
+        });
+      }
+
+      const allowedData: Record<string, unknown> = {};
       if (typeof input.data?.title === 'string') allowedData.title = input.data.title;
       if (typeof input.data?.isPublic === 'boolean') allowedData.isPublic = input.data.isPublic;
-      if (input.data?.content !== undefined) allowedData.content = input.data.content as any;
-      if (typeof (input.data as any)?.folderId === 'string') (allowedData as any).folderId = (input.data as any).folderId;
+      if (typeof (input.data as any)?.folderId === 'string') allowedData.folderId = (input.data as any).folderId;
+
+      let contentChanged = false;
+      if (input.data?.content !== undefined) {
+        const incomingContent = input.data.content as unknown;
+        const incomingHash = fingerprint(incomingContent);
+        contentChanged = incomingHash !== currentHash;
+
+        const incomingHasBody = hasMeaningfulContent(incomingContent);
+        const hadPrevious = hasMeaningfulContent(document.content as unknown);
+        if (!incomingHasBody && hadPrevious) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: '내용이 비어 있어 기존 문서를 덮어쓸 수 없습니다.',
+          });
+        }
+
+        if (contentChanged) {
+          allowedData.content = incomingContent as any;
+        }
+      }
+
+      if (!Object.keys(allowedData).length) {
+        return document;
+      }
+
+      if (contentChanged) {
+        await ctx.prisma.documentRevision.create({
+          data: {
+            documentId: document.id,
+            userId: ctx.user.id,
+            content: document.content,
+          },
+        });
+        await pruneOldRevisions(ctx.prisma, document.id);
+      }
 
       const updated = await ctx.prisma.document.update({
         where: { id: input.id },
@@ -140,6 +240,74 @@ export const documentRouter = createTRPCRouter({
       });
 
       return updated;
+    }),
+
+  revisions: protectedProcedure
+    .input(z.object({ documentId: z.string(), limit: z.number().min(1).max(50).default(20) }))
+    .query(async ({ ctx, input }) => {
+      const document = await ctx.prisma.document.findUnique({
+        where: { id: input.documentId },
+        select: { userId: true },
+      });
+
+      if (!document || document.userId !== ctx.user.id) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: '이 문서의 리비전을 조회할 권한이 없습니다.',
+        });
+      }
+
+      const revisions = await ctx.prisma.documentRevision.findMany({
+        where: { documentId: input.documentId },
+        orderBy: { createdAt: 'desc' },
+        take: input.limit,
+      });
+
+      return revisions;
+    }),
+
+  restoreFromRevision: protectedProcedure
+    .input(z.object({ documentId: z.string(), revisionId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const document = await ctx.prisma.document.findUnique({
+        where: { id: input.documentId },
+      });
+
+      if (!document || document.userId !== ctx.user.id) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: '이 문서를 복구할 권한이 없습니다.',
+        });
+      }
+
+      const revision = await ctx.prisma.documentRevision.findUnique({
+        where: { id: input.revisionId },
+      });
+
+      if (!revision || revision.documentId !== input.documentId) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: '리비전을 찾을 수 없습니다.',
+        });
+      }
+
+      await ctx.prisma.documentRevision.create({
+        data: {
+          documentId: document.id,
+          userId: ctx.user.id,
+          content: document.content,
+        },
+      });
+      await pruneOldRevisions(ctx.prisma, document.id);
+
+      const restored = await ctx.prisma.document.update({
+        where: { id: input.documentId },
+        data: {
+          content: revision.content,
+        },
+      });
+
+      return restored;
     }),
 
   // 문서 삭제 (소유권 검증 포함)

--- a/types/database.ts
+++ b/types/database.ts
@@ -33,6 +33,7 @@ export type Database = {
           title: string;
           content: any; // JSON type
           userId: string | null;
+          folderId: string | null;
           isPublic: boolean;
           createdAt: string;
           updatedAt: string;
@@ -42,6 +43,7 @@ export type Database = {
           title: string;
           content: any;
           userId?: string | null;
+          folderId?: string | null;
           isPublic?: boolean;
           createdAt?: string;
           updatedAt?: string;
@@ -51,9 +53,33 @@ export type Database = {
           title?: string;
           content?: any;
           userId?: string | null;
+          folderId?: string | null;
           isPublic?: boolean;
           createdAt?: string;
           updatedAt?: string;
+        };
+      };
+      document_revisions: {
+        Row: {
+          id: string;
+          documentId: string;
+          userId: string | null;
+          content: any;
+          createdAt: string;
+        };
+        Insert: {
+          id?: string;
+          documentId: string;
+          userId?: string | null;
+          content: any;
+          createdAt?: string;
+        };
+        Update: {
+          id?: string;
+          documentId?: string;
+          userId?: string | null;
+          content?: any;
+          createdAt?: string;
         };
       };
       bible_references: {


### PR DESCRIPTION
## Summary
- add Prisma `document_revisions` table with seven-day pruning
- block empty overwrites and record revisions on create/update/restore
- surface revision list & conflict messaging in the editor client

## Testing
- npm run lint *(fails: apps/mobile and packages/core lack "lint" script)*
- npx tsc --noEmit *(fails: existing mobile tRPC type errors)*