### PR TITLE
feat(core): add document and folder service interfaces

### DIFF
--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useFolderTabs } from '@/hooks/useFolderTabs';
 import { FolderTabsManagerDialog } from '@/components/documents/FolderTabsManagerDialog';
 import { DocumentListItem } from '@/components/documents/DocumentListItem';
+import { useDocumentService } from '@/lib/api/services/useDocumentService';
 import type { DocumentListEntry } from 'core';
 
 const DOCUMENT_PAGE_LIMIT = 50;
@@ -62,24 +63,21 @@ export default function DocumentsPage() {
     }
   );
 
-  const deleteDocument = api.document.delete.useMutation({
-    onSuccess: () => {
-      documentsQuery.refetch();
-      toast.success('문서가 삭제되었습니다');
-    },
-    onError: (error) => {
-      console.error('문서 삭제 실패:', error);
-      toast.error('문서 삭제에 실패했습니다');
-    },
-  });
+  const documentService = useDocumentService();
 
   const documents: DocumentListEntry[] = documentsQuery.data?.documents ?? [];
   const isLoadingDocuments = documentsQuery.isLoading;
   const isErrorDocuments = documentsQuery.isError;
 
   const handleDelete = async (id: string) => {
-    if (confirm('정말로 이 문서를 삭제하시겠습니까?')) {
-      await deleteDocument.mutateAsync({ id });
+    if (!confirm('정말로 이 문서를 삭제하시겠습니까?')) return;
+    try {
+      await documentService.delete(id);
+      documentsQuery.refetch();
+      toast.success('문서가 삭제되었습니다');
+    } catch (error) {
+      console.error('문서 삭제 실패:', error);
+      toast.error('문서 삭제에 실패했습니다');
     }
   };
 

--- a/app/folders/[folderId]/page.tsx
+++ b/app/folders/[folderId]/page.tsx
@@ -29,6 +29,8 @@ import toast from 'react-hot-toast';
 import { api } from '@/utils/api';
 import { extractPlainTextFromTiptap, formatDateTimeKST } from 'core';
 import type { DocumentListEntry, FolderSummary } from 'core';
+import { useDocumentService } from '@/lib/api/services/useDocumentService';
+import { useFolderService } from '@/lib/api/services/useFolderService';
 import DocumentGridSkeleton from '@/components/skeleton/DocumentGridSkeleton';
 import FolderHeaderSkeleton from '@/components/skeleton/FolderHeaderSkeleton';
 
@@ -66,6 +68,9 @@ export default function FolderDocumentsPage() {
   const documents: DocumentListEntry[] = documentsData?.documents ?? [];
   const folderList: FolderSummary[] = (folders ?? []) as FolderSummary[];
 
+  const documentService = useDocumentService();
+  const folderService = useFolderService();
+
   // 폴더 수정/삭제 관련 뮤테이션
   const updateFolder = api.folder.update.useMutation({
     onSuccess: () => {
@@ -79,42 +84,18 @@ export default function FolderDocumentsPage() {
       toast.error(msg);
     },
   });
-  const deleteFolder = api.folder.delete.useMutation({
-    onSuccess: () => {
-      toast.success('폴더를 삭제했습니다');
-    },
-    onError: () => toast.error('폴더 삭제에 실패했습니다'),
-  });
-  const normalizeUncategorized = api.folder.normalizeUncategorized.useMutation();
-
-  const deleteDocument = api.document.delete.useMutation({
-    onSuccess: () => {
-      refetch();
-      toast.success('문서가 삭제되었습니다');
-      setSelectedDocs([]);
-    },
-    onError: (_error) => {
-      toast.error('문서 삭제에 실패했습니다');
-    },
-  });
-
-  const moveDocuments = api.folder.moveDocuments.useMutation({
-    onSuccess: (data) => {
-      refetch();
-      toast.success(`${data.movedCount}개 문서를 ${data.targetFolder} 폴더로 이동했습니다`);
-      setSelectedDocs([]);
-      setShowMoveConfirm(false);
-    },
-    onError: (_error) => {
-      toast.error('문서 이동에 실패했습니다');
-    },
-  });
 
   const handleDeleteDocument = async (id: string, event: React.MouseEvent) => {
     event.stopPropagation();
-    
-    if (confirm('정말로 이 문서를 삭제하시겠습니까?')) {
-      await deleteDocument.mutateAsync({ id });
+    if (!confirm('정말로 이 문서를 삭제하시겠습니까?')) return;
+    try {
+      await documentService.delete(id);
+      refetch();
+      toast.success('문서가 삭제되었습니다');
+      setSelectedDocs([]);
+    } catch (error) {
+      console.error('문서 삭제 실패:', error);
+      toast.error('문서 삭제에 실패했습니다');
     }
   };
 
@@ -162,10 +143,19 @@ export default function FolderDocumentsPage() {
   };
 
   const handleMoveConfirm = async () => {
-    await moveDocuments.mutateAsync({
-      documentIds: selectedDocs,
-      targetFolderId,
-    });
+    try {
+      const result = await folderService.moveDocuments({
+        documentIds: selectedDocs,
+        targetFolderId,
+      });
+      refetch();
+      toast.success(`${result.movedCount}개 문서를 ${result.targetFolder} 폴더로 이동했습니다`);
+      setSelectedDocs([]);
+      setShowMoveConfirm(false);
+    } catch (error) {
+      console.error('문서 이동 실패:', error);
+      toast.error('문서 이동에 실패했습니다');
+    }
   };
 
   // 편집 모달 열기 시 기본값 세팅
@@ -483,11 +473,22 @@ export default function FolderDocumentsPage() {
               <p>이 폴더에는 문서가 없습니다. 삭제하시겠습니까?</p>
               <div className="flex justify-end gap-2">
                 <Button variant="outline" onClick={() => setShowDeleteModal(false)}>취소</Button>
-                <Button variant="destructive" onClick={async () => {
-                  await deleteFolder.mutateAsync({ id: folderId });
-                  setShowDeleteModal(false);
-                  router.push('/documents');
-                }}>삭제</Button>
+                <Button
+                  variant="destructive"
+                  onClick={async () => {
+                    try {
+                      await folderService.delete(folderId);
+                      toast.success('폴더를 삭제했습니다');
+                      setShowDeleteModal(false);
+                      router.push('/documents');
+                    } catch (error) {
+                      console.error('폴더 삭제 실패:', error);
+                      toast.error('폴더 삭제에 실패했습니다');
+                    }
+                  }}
+                >
+                  삭제
+                </Button>
               </div>
             </div>
           ) : (
@@ -497,13 +498,18 @@ export default function FolderDocumentsPage() {
                 <Button
                   variant="secondary"
                   onClick={async () => {
-                    const unc = await normalizeUncategorized.mutateAsync();
-                    const docIds = documents.map(d => d.id);
-                    await moveDocuments.mutateAsync({ documentIds: docIds, targetFolderId: unc.folderId });
-                    await deleteFolder.mutateAsync({ id: folderId });
-                    setShowDeleteModal(false);
-                    toast.success('미분류로 이동 후 폴더를 삭제했습니다');
-                    router.push('/documents');
+                    try {
+                      const unc = await folderService.normalizeUncategorized();
+                      const docIds = documents.map((d) => d.id);
+                      await folderService.moveDocuments({ documentIds: docIds, targetFolderId: unc.folderId });
+                      await folderService.delete(folderId);
+                      setShowDeleteModal(false);
+                      toast.success('미분류로 이동 후 폴더를 삭제했습니다');
+                      router.push('/documents');
+                    } catch (error) {
+                      console.error('폴더 삭제 실패:', error);
+                      toast.error('폴더 삭제에 실패했습니다');
+                    }
                   }}
                 >
                   미분류로 모두 이동 후 삭제
@@ -515,12 +521,17 @@ export default function FolderDocumentsPage() {
                       <button
                         key={f.id}
                         onClick={async () => {
-                          const docIds = documents.map(d => d.id);
-                          await moveDocuments.mutateAsync({ documentIds: docIds, targetFolderId: f.id });
-                          await deleteFolder.mutateAsync({ id: folderId });
-                          setShowDeleteModal(false);
-                          toast.success(`${f.name}로 이동 후 폴더를 삭제했습니다`);
-                          router.push('/documents');
+                          try {
+                            const docIds = documents.map((d) => d.id);
+                            await folderService.moveDocuments({ documentIds: docIds, targetFolderId: f.id });
+                            await folderService.delete(folderId);
+                            setShowDeleteModal(false);
+                            toast.success(`${f.name}로 이동 후 폴더를 삭제했습니다`);
+                            router.push('/documents');
+                          } catch (error) {
+                            console.error('폴더 삭제 실패:', error);
+                            toast.error('폴더 삭제에 실패했습니다');
+                          }
                         }}
                         className="w-full text-left px-3 py-2 hover:bg-gray-100 flex items-center justify-between"
                       >

--- a/lib/api/services/useDocumentService.ts
+++ b/lib/api/services/useDocumentService.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useMemo } from 'react';
+import { api } from '@/utils/api';
+import type {
+  DocumentCreateInput,
+  DocumentListParams,
+  DocumentListResult,
+  DocumentService,
+  DocumentUpdateInput,
+} from 'core';
+
+export function useDocumentService(): DocumentService {
+  const utils = api.useUtils();
+  const createMutation = api.document.create.useMutation();
+  const updateMutation = api.document.update.useMutation();
+  const deleteMutation = api.document.delete.useMutation();
+  const restoreMutation = api.document.restoreFromRevision.useMutation();
+
+  return useMemo(() => {
+    const list: DocumentService['list'] = async (params?: DocumentListParams): Promise<DocumentListResult> => {
+      const result = await utils.document.list.fetch(params ?? {});
+      return {
+        documents: result.documents,
+        nextCursor: result.nextCursor,
+      };
+    };
+
+    const getById: DocumentService['getById'] = async (id) => {
+      return utils.document.getById.fetch({ id });
+    };
+
+    const create: DocumentService['create'] = async (input: DocumentCreateInput) => {
+      return createMutation.mutateAsync(input);
+    };
+
+    const update: DocumentService['update'] = async (id, input: DocumentUpdateInput) => {
+      const { expectedHash, ...data } = input;
+      return updateMutation.mutateAsync({ id, data, expectedHash });
+    };
+
+    const remove: DocumentService['delete'] = async (id) => {
+      await deleteMutation.mutateAsync({ id });
+    };
+
+    const getRevisions: DocumentService['getRevisions'] = async (documentId, limit) => {
+      return utils.document.revisions.fetch({ documentId, limit });
+    };
+
+    const restoreFromRevision: DocumentService['restoreFromRevision'] = async (documentId, revisionId) => {
+      return restoreMutation.mutateAsync({ documentId, revisionId });
+    };
+
+    return {
+      list,
+      getById,
+      create,
+      update,
+      delete: remove,
+      getRevisions,
+      restoreFromRevision,
+    };
+  }, [createMutation, deleteMutation, restoreMutation, updateMutation, utils]);
+}

--- a/lib/api/services/useFolderService.ts
+++ b/lib/api/services/useFolderService.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import { useMemo } from 'react';
+import { api } from '@/utils/api';
+import type {
+  FolderCreateInput,
+  FolderService,
+  FolderUpdateInput,
+  MoveDocumentsInput,
+  MoveDocumentsResult,
+  NormalizeResult,
+} from 'core';
+
+export function useFolderService(): FolderService {
+  const utils = api.useUtils();
+  const createMutation = api.folder.create.useMutation();
+  const updateMutation = api.folder.update.useMutation();
+  const deleteMutation = api.folder.delete.useMutation();
+  const moveMutation = api.folder.moveDocuments.useMutation();
+  const normalizeMutation = api.folder.normalizeUncategorized.useMutation();
+
+  return useMemo(() => {
+    const list: FolderService['list'] = async () => {
+      return utils.folder.list.fetch();
+    };
+
+    const getById: FolderService['getById'] = async (id) => {
+      return utils.folder.getById.fetch({ id });
+    };
+
+    const getDocuments: FolderService['getDocuments'] = async (folderId) => {
+      const result = await utils.folder.getDocuments.fetch({ folderId });
+      return result.documents;
+    };
+
+    const create: FolderService['create'] = async (input: FolderCreateInput) => {
+      return createMutation.mutateAsync(input);
+    };
+
+    const update: FolderService['update'] = async (input: FolderUpdateInput) => {
+      return updateMutation.mutateAsync(input);
+    };
+
+    const remove: FolderService['delete'] = async (id) => {
+      await deleteMutation.mutateAsync({ id });
+    };
+
+    const moveDocuments: FolderService['moveDocuments'] = async (input: MoveDocumentsInput): Promise<MoveDocumentsResult> => {
+      return moveMutation.mutateAsync(input);
+    };
+
+    const normalizeUncategorized: FolderService['normalizeUncategorized'] = async (): Promise<NormalizeResult> => {
+      return normalizeMutation.mutateAsync();
+    };
+
+    return {
+      list,
+      getById,
+      getDocuments,
+      create,
+      update,
+      delete: remove,
+      moveDocuments,
+      normalizeUncategorized,
+    };
+  }, [createMutation, deleteMutation, moveMutation, normalizeMutation, updateMutation, utils]);
+}

--- a/packages/core/src/domain/document.ts
+++ b/packages/core/src/domain/document.ts
@@ -15,3 +15,18 @@ export interface DocumentListEntry extends DocumentIdentifier, DocumentTimestamp
 }
 
 export type DocumentList = DocumentListEntry[];
+
+export interface DocumentDetail extends DocumentListEntry {
+  title: string;
+  folderId: string | null;
+  isPublic: boolean;
+}
+
+export interface DocumentRevision extends DocumentIdentifier {
+  documentId: string;
+  userId?: string | null;
+  content: unknown;
+  createdAt: string | Date;
+}
+
+export type DocumentRevisionList = DocumentRevision[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,5 @@ export * from './domain/constants';
 export * from './domain/document';
 export * from './domain/folder';
 export * from './editor/content';
+export * from './services/document';
+export * from './services/folder';

--- a/packages/core/src/services/document.ts
+++ b/packages/core/src/services/document.ts
@@ -1,0 +1,44 @@
+import type {
+  DocumentDetail,
+  DocumentList,
+  DocumentRevisionList,
+} from '../domain/document';
+import type { SermonInfo } from '../domain/sermon';
+
+export interface DocumentListParams {
+  limit?: number;
+  cursor?: string;
+  folderId?: string;
+}
+
+export interface DocumentCreateInput {
+  title: string;
+  content: unknown;
+  sermonInfo?: Partial<SermonInfo> & { date?: string };
+  isPublic?: boolean;
+  folderId?: string;
+}
+
+export interface DocumentUpdateInput {
+  title?: string;
+  content?: unknown;
+  sermonInfo?: Partial<SermonInfo> & { date?: string };
+  isPublic?: boolean;
+  folderId?: string;
+  expectedHash?: string;
+}
+
+export interface DocumentListResult {
+  documents: DocumentList;
+  nextCursor?: string;
+}
+
+export interface DocumentService {
+  list(params?: DocumentListParams): Promise<DocumentListResult>;
+  getById(id: string): Promise<DocumentDetail>;
+  create(input: DocumentCreateInput): Promise<DocumentDetail>;
+  update(id: string, input: DocumentUpdateInput): Promise<DocumentDetail>;
+  delete(id: string): Promise<void>;
+  getRevisions(documentId: string, limit?: number): Promise<DocumentRevisionList>;
+  restoreFromRevision(documentId: string, revisionId: string): Promise<DocumentDetail>;
+}

--- a/packages/core/src/services/folder.ts
+++ b/packages/core/src/services/folder.ts
@@ -1,0 +1,38 @@
+import type { DocumentList } from '../domain/document';
+import type { FolderList, FolderSummary } from '../domain/folder';
+
+export interface FolderCreateInput {
+  name: string;
+  icon?: string;
+  color?: string;
+}
+
+export interface FolderUpdateInput extends FolderCreateInput {
+  id: string;
+}
+
+export interface MoveDocumentsInput {
+  documentIds: string[];
+  targetFolderId: string;
+}
+
+export interface MoveDocumentsResult {
+  movedCount: number;
+  targetFolder: string;
+}
+
+export interface NormalizeResult {
+  folderId: string;
+  movedCount: number;
+}
+
+export interface FolderService {
+  list(): Promise<FolderList>;
+  getById(id: string): Promise<FolderSummary>;
+  getDocuments(folderId: string): Promise<DocumentList>;
+  create(input: FolderCreateInput): Promise<FolderSummary>;
+  update(input: FolderUpdateInput): Promise<FolderSummary>;
+  delete(id: string): Promise<void>;
+  moveDocuments(input: MoveDocumentsInput): Promise<MoveDocumentsResult>;
+  normalizeUncategorized(): Promise<NormalizeResult>;
+}


### PR DESCRIPTION
## Summary
- define document/folder service interfaces in core package
- add web implementations via useDocumentService/useFolderService hooks
- refactor documents and folder pages to use shared service layer

## Testing
- npm run lint