### PR TITLE
feat(platform): add web auth and toast adapters

### DIFF
--- a/adapters/web/auth.ts
+++ b/adapters/web/auth.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { createClient } from '@/lib/supabase/client';
+import type { Session } from '@supabase/supabase-js';
+import type { AuthPort, AuthSession } from '@/ports/auth';
+
+async function syncSupabaseSession(session: Session | null) {
+  try {
+    await fetch('/auth/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: session ? 'SIGNED_IN' : 'SIGNED_OUT', session }),
+      credentials: 'include',
+    });
+  } catch (error) {
+    console.warn('세션 동기화 실패:', error);
+  }
+}
+
+function mapSession(session: Session | null): AuthSession {
+  if (!session) {
+    return { userId: null, accessToken: null, refreshToken: null };
+  }
+  return {
+    userId: session.user?.id ?? null,
+    accessToken: session.access_token ?? null,
+    refreshToken: session.refresh_token ?? null,
+  };
+}
+
+export const webAuthPort: AuthPort = {
+  async getSession(): Promise<AuthSession> {
+    const supabase = createClient();
+    const { data } = await supabase.auth.getSession();
+    return mapSession(data.session ?? null);
+  },
+
+  async signInWithPassword(email: string, password: string): Promise<AuthSession> {
+    const supabase = createClient();
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      throw new Error(error.message);
+    }
+    const session = data.session ?? (await supabase.auth.getSession()).data.session ?? null;
+    const mapped = mapSession(session);
+    if (session) {
+      await syncSupabaseSession(session);
+    }
+    return mapped;
+  },
+
+  async signOut(): Promise<void> {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    await syncSupabaseSession(null);
+  },
+};

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ListFilter, Plus } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { toastPort } from '@/lib/toast';
 
 import { api } from '@/utils/api';
 import { Button } from '@/components/ui/button';
@@ -74,10 +75,10 @@ export default function DocumentsPage() {
     try {
       await documentService.delete(id);
       documentsQuery.refetch();
-      toast.success('문서가 삭제되었습니다');
+      toastPort.success('문서가 삭제되었습니다');
     } catch (error) {
       console.error('문서 삭제 실패:', error);
-      toast.error('문서 삭제에 실패했습니다');
+      toastPort.error('문서 삭제에 실패했습니다');
     }
   };
 

--- a/app/folders/[folderId]/page.tsx
+++ b/app/folders/[folderId]/page.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { FileText, Trash2, Plus, Share2, ArrowLeft, MoveRight, Pencil } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { toastPort } from '@/lib/toast';
 import { api } from '@/utils/api';
 import { extractPlainTextFromTiptap, formatDateTimeKST } from 'core';
 import type { DocumentListEntry, FolderSummary } from 'core';
@@ -74,14 +75,14 @@ export default function FolderDocumentsPage() {
   // 폴더 수정/삭제 관련 뮤테이션
   const updateFolder = api.folder.update.useMutation({
     onSuccess: () => {
-      toast.success('폴더가 수정되었습니다');
+      toastPort.success('폴더가 수정되었습니다');
       setShowEditModal(false);
       refetch();
       router.refresh();
     },
     onError: (e) => {
       const msg = (e as { message?: string })?.message || '수정에 실패했습니다';
-      toast.error(msg);
+      toastPort.error(msg);
     },
   });
 
@@ -91,11 +92,11 @@ export default function FolderDocumentsPage() {
     try {
       await documentService.delete(id);
       refetch();
-      toast.success('문서가 삭제되었습니다');
+      toastPort.success('문서가 삭제되었습니다');
       setSelectedDocs([]);
     } catch (error) {
       console.error('문서 삭제 실패:', error);
-      toast.error('문서 삭제에 실패했습니다');
+      toastPort.error('문서 삭제에 실패했습니다');
     }
   };
 
@@ -125,7 +126,7 @@ export default function FolderDocumentsPage() {
 
   const handleMoveClick = () => {
     if (selectedDocs.length === 0) {
-      toast.error('이동할 문서를 선택해주세요');
+      toastPort.error('이동할 문서를 선택해주세요');
       return;
     }
     setShowFolderSelect(true);
@@ -133,7 +134,7 @@ export default function FolderDocumentsPage() {
 
   const handleFolderSelect = (selectedFolderId: string, folderName: string) => {
     if (selectedFolderId === folderId) {
-      toast.error('같은 폴더로는 이동할 수 없습니다');
+      toastPort.error('같은 폴더로는 이동할 수 없습니다');
       return;
     }
     setTargetFolderId(selectedFolderId);
@@ -149,12 +150,12 @@ export default function FolderDocumentsPage() {
         targetFolderId,
       });
       refetch();
-      toast.success(`${result.movedCount}개 문서를 ${result.targetFolder} 폴더로 이동했습니다`);
+      toastPort.success(`${result.movedCount}개 문서를 ${result.targetFolder} 폴더로 이동했습니다`);
       setSelectedDocs([]);
       setShowMoveConfirm(false);
     } catch (error) {
       console.error('문서 이동 실패:', error);
-      toast.error('문서 이동에 실패했습니다');
+      toastPort.error('문서 이동에 실패했습니다');
     }
   };
 
@@ -451,7 +452,7 @@ export default function FolderDocumentsPage() {
             <Button variant="outline" onClick={() => setShowEditModal(false)}>취소</Button>
             <Button
               onClick={async () => {
-                if (!editName.trim()) { toast.error('폴더명을 입력하세요'); return; }
+                if (!editName.trim()) { toastPort.error('폴더명을 입력하세요'); return; }
                 await updateFolder.mutateAsync({ id: folderId, name: editName.trim(), icon: editIcon, color: editColor });
               }}
               disabled={updateFolder.isPending}
@@ -478,12 +479,12 @@ export default function FolderDocumentsPage() {
                   onClick={async () => {
                     try {
                       await folderService.delete(folderId);
-                      toast.success('폴더를 삭제했습니다');
+                      toastPort.success('폴더를 삭제했습니다');
                       setShowDeleteModal(false);
                       router.push('/documents');
                     } catch (error) {
                       console.error('폴더 삭제 실패:', error);
-                      toast.error('폴더 삭제에 실패했습니다');
+                      toastPort.error('폴더 삭제에 실패했습니다');
                     }
                   }}
                 >
@@ -504,11 +505,11 @@ export default function FolderDocumentsPage() {
                       await folderService.moveDocuments({ documentIds: docIds, targetFolderId: unc.folderId });
                       await folderService.delete(folderId);
                       setShowDeleteModal(false);
-                      toast.success('미분류로 이동 후 폴더를 삭제했습니다');
+                      toastPort.success('미분류로 이동 후 폴더를 삭제했습니다');
                       router.push('/documents');
                     } catch (error) {
                       console.error('폴더 삭제 실패:', error);
-                      toast.error('폴더 삭제에 실패했습니다');
+                      toastPort.error('폴더 삭제에 실패했습니다');
                     }
                   }}
                 >
@@ -526,11 +527,11 @@ export default function FolderDocumentsPage() {
                             await folderService.moveDocuments({ documentIds: docIds, targetFolderId: f.id });
                             await folderService.delete(folderId);
                             setShowDeleteModal(false);
-                            toast.success(`${f.name}로 이동 후 폴더를 삭제했습니다`);
+                            toastPort.success(`${f.name}로 이동 후 폴더를 삭제했습니다`);
                             router.push('/documents');
                           } catch (error) {
                             console.error('폴더 삭제 실패:', error);
-                            toast.error('폴더 삭제에 실패했습니다');
+                            toastPort.error('폴더 삭제에 실패했습니다');
                           }
                         }}
                         className="w-full text-left px-3 py-2 hover:bg-gray-100 flex items-center justify-between"

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -2,13 +2,13 @@
 
 import { Suspense, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loader2, Mail, Lock } from 'lucide-react';
 import Link from 'next/link';
+import { webAuthPort } from '@/adapters/web/auth';
 
 const redirectToKey = 'redirectTo';
 
@@ -18,7 +18,6 @@ function LoginFormInner({ redirectTo }: { redirectTo: string }) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
-  const supabase = createClient();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,33 +25,15 @@ function LoginFormInner({ redirectTo }: { redirectTo: string }) {
     setError(null);
 
     try {
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
-
-      if (error) {
-        setError(error.message);
+      await webAuthPort.signInWithPassword(email, password);
+      router.push(redirectTo);
+      router.refresh();
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
       } else {
-        try {
-          const session = data.session ?? (await supabase.auth.getSession()).data.session;
-          if (session) {
-            await fetch('/auth/callback', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ event: 'SIGNED_IN', session }),
-              credentials: 'include',
-            });
-          }
-        } catch (syncError) {
-          console.error('세션 동기화 실패:', syncError);
-        }
-
-        router.push(redirectTo);
-        router.refresh();
+        setError('로그인 중 오류가 발생했습니다.');
       }
-    } catch {
-      setError('로그인 중 오류가 발생했습니다.');
     } finally {
       setIsLoading(false);
     }

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -7,6 +7,7 @@ import toast, { type Renderable, type Toast as HotToast } from 'react-hot-toast'
 import type { AppError } from '@/lib/errors/types';
 import { getUserMessage } from '@/lib/errors/types';
 import { logger } from '@/lib/logger';
+import type { ToastPort } from '@/ports/toast';
 
 /**
  * Toast 옵션 인터페이스
@@ -285,6 +286,21 @@ export class ToastManager {
     });
   }
 }
+
+export const toastPort: ToastPort = {
+  success: (message: string) => {
+    ToastManager.showSuccess(message);
+  },
+  error: (message: string) => {
+    ToastManager.showError(message);
+  },
+  info: (message: string) => {
+    ToastManager.showInfo(message);
+  },
+  warning: (message: string) => {
+    ToastManager.showWarning(message);
+  },
+};
 
 // 간편 사용을 위한 export
 export const showError = ToastManager.showError;

--- a/ports/auth.ts
+++ b/ports/auth.ts
@@ -1,0 +1,11 @@
+export interface AuthSession {
+  userId: string | null;
+  accessToken?: string | null;
+  refreshToken?: string | null;
+}
+
+export interface AuthPort {
+  getSession(): Promise<AuthSession>;
+  signInWithPassword(email: string, password: string): Promise<AuthSession>;
+  signOut(): Promise<void>;
+}

--- a/ports/toast.ts
+++ b/ports/toast.ts
@@ -1,0 +1,6 @@
+export interface ToastPort {
+  success(message: string): void;
+  error(message: string): void;
+  info?(message: string): void;
+  warning?(message: string): void;
+}


### PR DESCRIPTION
## Summary
- introduce auth/toast ports and web adapters implementing them
- expose toastPort via lib/toast and auth web adapter via adapters/web/auth
- migrate login/documents/folders surfaces to new adapters

## Testing
- npm run lint