### PR TITLE
fix(redirects): align legacy folders pages with Next.js 15 PageProps

### DIFF
--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ListFilter, Plus } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -17,6 +17,8 @@ import { DocumentListItem } from '@/components/documents/DocumentListItem';
 import { useDocumentService } from '@/lib/api/services/useDocumentService';
 import type { DocumentListEntry } from 'core';
 
+export const dynamic = 'force-dynamic';
+
 const DOCUMENT_PAGE_LIMIT = 50;
 
 type TRPCErrorPayload = {
@@ -32,7 +34,7 @@ const getErrorCode = (error: unknown): string | undefined => {
   return typeof code === 'string' ? code : undefined;
 };
 
-export default function DocumentsPage() {
+function DocumentsPageContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -251,5 +253,32 @@ export default function DocumentsPage() {
         }}
       />
     </div>
+  );
+}
+
+function DocumentsPageFallback() {
+  return (
+    <div className="max-w-5xl mx-auto px-3 py-4 pb-24 space-y-5">
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Card key={idx} className="p-4">
+            <Skeleton className="h-4 w-1/3" />
+            <div className="mt-3 space-y-2">
+              <Skeleton className="h-3 w-2/3" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+            <Skeleton className="mt-3 h-3 w-1/4" />
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function DocumentsPage() {
+  return (
+    <Suspense fallback={<DocumentsPageFallback />}>
+      <DocumentsPageContent />
+    </Suspense>
   );
 }

--- a/app/folders/[folderId]/page.tsx
+++ b/app/folders/[folderId]/page.tsx
@@ -1,12 +1,11 @@
-import { redirect } from 'next/navigation';
+import { permanentRedirect } from 'next/navigation';
 
 type LegacyFolderPageProps = {
-  params: {
-    folderId: string;
-  };
+  params: Promise<{ folderId: string }>;
 };
 
-export default function LegacyFolderPage({ params }: LegacyFolderPageProps) {
-  const query = new URLSearchParams({ folderId: params.folderId });
-  redirect(`/documents?${query.toString()}`);
+export default async function LegacyFolderPage({ params }: LegacyFolderPageProps) {
+  const { folderId } = await params;
+  const query = new URLSearchParams({ folderId });
+  permanentRedirect(`/documents?${query.toString()}`);
 }

--- a/app/folders/page.tsx
+++ b/app/folders/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from 'next/navigation';
+import { permanentRedirect } from 'next/navigation';
 
 export default function LegacyFoldersPage() {
-  redirect('/documents');
+  permanentRedirect('/documents');
 }


### PR DESCRIPTION
## Summary
- Next.js 15에서 params Promise 타입을 고려해 동적 폴더 리다이렉트를 컴파일 가능하도록 보완
- legacy /folder(s) 페이지는 permanentRedirect로 308을 명시
- /documents 페이지는 Suspense와 dynamic='force-dynamic'으로 CSR bail-out 요건을 충족

## Testing
- npm run lint
- vercel deploy --yes
