### PR TITLE
fix: gap 커서 런타임 판별 보완

### DIFF
--- a/components/editor/HolyEditor.tsx
+++ b/components/editor/HolyEditor.tsx
@@ -339,7 +339,11 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
       const { state } = instance;
       const { selection, schema } = state;
 
-      if (!(selection instanceof ProseMirrorGapCursor)) {
+      const isGapCursor =
+        selection instanceof ProseMirrorGapCursor ||
+        (selection && selection.constructor && selection.constructor.name === 'GapCursor');
+
+      if (!isGapCursor) {
         return;
       }
 


### PR DESCRIPTION
## 요약
- GapCursor 판별 조건을 보완해 프로덕션 번들에서도 gap 커서가 인식되도록 했습니다.
- selection의 constructor 이름을 추가 검사해 instanceof 실패 시에도 빈 문단 삽입 로직이 실행됩니다.

## 테스트
- (건너뜀) 로컬 빌드 없이 적용
