### PR TITLE
fix: gap 커서 유형 감지 안정화

### DIFF
--- a/components/editor/HolyEditor.tsx
+++ b/components/editor/HolyEditor.tsx
@@ -339,9 +339,14 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
       const { state } = instance;
       const { selection, schema } = state;
 
+      const selectionType =
+        typeof (selection as { toJSON?: () => { type?: string } }).toJSON === 'function'
+          ? (selection as { toJSON: () => { type?: string } }).toJSON()?.type
+          : undefined;
+
       const isGapCursor =
         selection instanceof ProseMirrorGapCursor ||
-        (selection && selection.constructor && selection.constructor.name === 'GapCursor');
+        selectionType === 'gapcursor';
 
       if (!isGapCursor) {
         return;


### PR DESCRIPTION
## 요약
- gap cursor 판별에 selection.toJSON()?.type === 'gapcursor' 검사를 추가했습니다.
- constructor 이름이 난독화되거나 모듈 중복으로 달라져도 빈 문단 삽입 로직이 실행되도록 했습니다.

## 테스트
- npm run lint
