### PR TITLE
chore: gap 커서 selection 로그 추가

### DIFF
--- a/components/editor/HolyEditor.tsx
+++ b/components/editor/HolyEditor.tsx
@@ -342,10 +342,31 @@ export default function HolyEditor({ documentId }: HolyEditorProps) {
       const selectionAsAny = selection as Selection & {
         constructor?: { name?: string };
         toJSON?: () => { type?: string };
+        from?: number;
+        to?: number;
+        $from?: { pos: number };
+        $to?: { pos: number };
       };
 
       const selectionType =
         typeof selectionAsAny.toJSON === 'function' ? selectionAsAny.toJSON()?.type : undefined;
+
+      if (typeof window !== 'undefined') {
+        const fromPos =
+          typeof selectionAsAny.from === 'number'
+            ? selectionAsAny.from
+            : selectionAsAny.$from?.pos;
+        const toPos =
+          typeof selectionAsAny.to === 'number'
+            ? selectionAsAny.to
+            : selectionAsAny.$to?.pos;
+        console.debug('[GapCursor] selectionUpdate', {
+          type: selectionType,
+          constructor: selectionAsAny.constructor?.name,
+          from: fromPos,
+          to: toPos,
+        });
+      }
 
       const isGapCursor =
         selection instanceof ProseMirrorGapCursor ||


### PR DESCRIPTION
## 요약
- selectionUpdate 이벤트에서 selection type, constructor, from/to 정보를 콘솔에 출력합니다.
- 프로덕션에서 gap cursor가 생성되는지 여부를 빠르게 파악할 수 있습니다.

## 테스트
- npm run lint
